### PR TITLE
Stop error swallowing

### DIFF
--- a/dist/lib/badger.js
+++ b/dist/lib/badger.js
@@ -135,7 +135,13 @@ var fromUSDC = function (amount) { return __awaiter(void 0, void 0, void 0, func
                 return [4 /*yield*/, UNISWAP.Fetcher.fetchPairData(USDC, WBTC, provider)];
             case 1:
                 route = new (_b.apply(_a, [void 0, [_c.sent()], USDC]))();
-                trade = new UNISWAP.Trade(route, new UNISWAP.TokenAmount(USDC, ethers.BigNumber.from(amount).toString()), UNISWAP.TradeType.EXACT_INPUT);
+                try {
+                    trade = new UNISWAP.Trade(route, new UNISWAP.TokenAmount(USDC, ethers.BigNumber.from(amount).toString()), UNISWAP.TradeType.EXACT_INPUT);
+                }
+                catch (e) {
+                    console.error("Insufficient USDC amount for price fetch");
+                    return [2 /*return*/, 0];
+                }
                 return [4 /*yield*/, renBTCFromWBTC(ethers.BigNumber.from(trade.outputAmount.raw.toString(10)))];
             case 2:
                 result = _c.sent();

--- a/dist/lib/mock.js
+++ b/dist/lib/mock.js
@@ -123,7 +123,6 @@ var createMockKeeper = function (provider) { return __awaiter(void 0, void 0, vo
         keeper = zero_1.createZeroKeeper({ on: function () { } });
         provider = provider || new ethers_1.ethers.providers.JsonRpcProvider('http://localhost:8545');
         keeperSigner = keeperSigner || provider.getSigner(exports.TEST_KEEPER_ADDRESS);
-        console.log(keepers.length);
         keepers.push(keeper);
         keeper.advertiseAsKeeper = function () { return __awaiter(void 0, void 0, void 0, function () { return __generator(this, function (_a) {
             return [2 /*return*/];
@@ -292,7 +291,6 @@ var enableGlobalMockRuntime = function () {
                 switch (_a.label) {
                     case 0:
                         _a.trys.push([0, 2, , 3]);
-                        console.log(keepers.length);
                         return [4 /*yield*/, Promise.all(keepers.map(function (v) { return __awaiter(_this, void 0, void 0, function () {
                                 return __generator(this, function (_a) {
                                     switch (_a.label) {

--- a/lib/badger.js
+++ b/lib/badger.js
@@ -63,21 +63,26 @@ const applyRenVMMintFee = (input) => {
 const fromUSDC = async (amount) => {
   const USDC = new UNISWAP.Token(UNISWAP.ChainId.MAINNET, fixtures.ETHEREUM.USDC, 6);
   const WBTC = new UNISWAP.Token(UNISWAP.ChainId.MAINNET, fixtures.ETHEREUM.WBTC, 8);
-  const route = new UNISWAP.Route([await UNISWAP.Fetcher.fetchPairData(USDC, WBTC, provider)], USDC); 
-  const trade = new UNISWAP.Trade(route, new UNISWAP.TokenAmount(USDC, ethers.BigNumber.from(amount).toString()), UNISWAP.TradeType.EXACT_INPUT);
+  const route = new UNISWAP.Route([await UNISWAP.Fetcher.fetchPairData(USDC, WBTC, provider)], USDC);
+  try {
+    const trade = new UNISWAP.Trade(route, new UNISWAP.TokenAmount(USDC, ethers.BigNumber.from(amount).toString()), UNISWAP.TradeType.EXACT_INPUT);
+  } catch(e) {
+    console.error("Insufficient USDC amount for price fetch");
+    return 0;
+  }
   const result = await renBTCFromWBTC(ethers.BigNumber.from(trade.outputAmount.raw.toString(10)));
   return result;
 };
 
 const toUSDC = async (amount) => {
   try {
-  const wbtcOut = await WBTCFromRenBTC(amount);
-  const USDC = new UNISWAP.Token(UNISWAP.ChainId.MAINNET, fixtures.ETHEREUM.USDC, 6);
-  const WBTC = new UNISWAP.Token(UNISWAP.ChainId.MAINNET, fixtures.ETHEREUM.WBTC, 8);
-  const route = new UNISWAP.Route([await UNISWAP.Fetcher.fetchPairData(WBTC, USDC, provider)], WBTC); 
-  const trade = new UNISWAP.Trade(route, new UNISWAP.TokenAmount(WBTC, ethers.BigNumber.from(wbtcOut).toString()), UNISWAP.TradeType.EXACT_INPUT);
-  const result = ethers.BigNumber.from(trade.outputAmount.raw.toString(10));
-  return result;
+    const wbtcOut = await WBTCFromRenBTC(amount);
+    const USDC = new UNISWAP.Token(UNISWAP.ChainId.MAINNET, fixtures.ETHEREUM.USDC, 6);
+    const WBTC = new UNISWAP.Token(UNISWAP.ChainId.MAINNET, fixtures.ETHEREUM.WBTC, 8);
+    const route = new UNISWAP.Route([await UNISWAP.Fetcher.fetchPairData(WBTC, USDC, provider)], WBTC); 
+    const trade = new UNISWAP.Trade(route, new UNISWAP.TokenAmount(WBTC, ethers.BigNumber.from(wbtcOut).toString()), UNISWAP.TradeType.EXACT_INPUT);
+    const result = ethers.BigNumber.from(trade.outputAmount.raw.toString(10));
+    return result;
   } catch (e) {
 	  console.error(e);
 	  return 0;

--- a/lib/mock.ts
+++ b/lib/mock.ts
@@ -46,7 +46,6 @@ export const createMockKeeper = async (provider?: any) => {
 	const keeper = (createZeroKeeper as any)({ on() {} });
 	provider = provider || new ethers.providers.JsonRpcProvider('http://localhost:8545');
 	keeperSigner = keeperSigner || provider.getSigner(TEST_KEEPER_ADDRESS);
-	console.log(keepers.length);
 	keepers.push(keeper);
 	keeper.advertiseAsKeeper = async () => {};
 	keeper.setTxDispatcher = async (fn) => {
@@ -145,7 +144,6 @@ export const enableGlobalMockRuntime = () => {
 	};
 	ZeroUser.prototype.publishBurnRequest = async function (burnRequest) {
 		try {
-			console.log(keepers.length);
 			await Promise.all(
 				keepers.map(async (v) => {
 					if (v._txDispatcher) return await v._txDispatcher(burnRequest, 'BURN');


### PR DESCRIPTION
This code removes a few annoying console logs and stops badger.js from swallowing an error when we fetch WBTC from USDC amount from Uniswap. 